### PR TITLE
Allow ObjectPropertyAccessExpression to be cast

### DIFF
--- a/src/Line/ObjectPropertyAccessExpression.php
+++ b/src/Line/ObjectPropertyAccessExpression.php
@@ -14,9 +14,9 @@ class ObjectPropertyAccessExpression extends AbstractExpression
     private $objectPlaceholder;
     private $property;
 
-    public function __construct(VariablePlaceholder $objectPlaceholder, string $property)
+    public function __construct(VariablePlaceholder $objectPlaceholder, string $property, ?string $castTo = null)
     {
-        parent::__construct();
+        parent::__construct($castTo);
 
         $this->objectPlaceholder = $objectPlaceholder;
         $this->property = $property;
@@ -39,7 +39,7 @@ class ObjectPropertyAccessExpression extends AbstractExpression
 
     public function render(): string
     {
-        return sprintf(
+        return parent::render() . sprintf(
             self::RENDER_PATTERN,
             $this->objectPlaceholder->render(),
             $this->property

--- a/tests/Unit/Line/ObjectPropertyAccessExpressionTest.php
+++ b/tests/Unit/Line/ObjectPropertyAccessExpressionTest.php
@@ -18,21 +18,34 @@ class ObjectPropertyAccessExpressionTest extends \PHPUnit\Framework\TestCase
     public function testCreate(
         VariablePlaceholder $objectPlaceholder,
         string $property,
+        ?string $castTo,
         MetadataInterface $expectedMetadata
     ) {
-        $invocation = new ObjectPropertyAccessExpression($objectPlaceholder, $property);
+        $invocation = new ObjectPropertyAccessExpression($objectPlaceholder, $property, $castTo);
 
         $this->assertSame($objectPlaceholder, $invocation->getObjectPlaceholder());
         $this->assertSame($property, $invocation->getProperty());
+        $this->assertSame($castTo, $invocation->getCastTo());
         $this->assertEquals($expectedMetadata, $invocation->getMetadata());
     }
 
     public function createDataProvider(): array
     {
         return [
-            'default' => [
+            'no castTo' => [
                 'objectPlaceholder' => VariablePlaceholder::createDependency('OBJECT'),
                 'property' => 'propertyName',
+                'castTo' => null,
+                'expectedMetadata' => new Metadata([
+                    Metadata::KEY_VARIABLE_DEPENDENCIES => VariablePlaceholderCollection::createDependencyCollection([
+                        'OBJECT',
+                    ]),
+                ]),
+            ],
+            'has castTo' => [
+                'objectPlaceholder' => VariablePlaceholder::createDependency('OBJECT'),
+                'property' => 'propertyName',
+                'castTo' => 'string',
                 'expectedMetadata' => new Metadata([
                     Metadata::KEY_VARIABLE_DEPENDENCIES => VariablePlaceholderCollection::createDependencyCollection([
                         'OBJECT',
@@ -53,12 +66,20 @@ class ObjectPropertyAccessExpressionTest extends \PHPUnit\Framework\TestCase
     public function renderDataProvider(): array
     {
         return [
-            'default' => [
+            'no castTo' => [
                 'expression' => new ObjectPropertyAccessExpression(
                     VariablePlaceholder::createDependency('OBJECT'),
                     'propertyName'
                 ),
                 'expectedString' => '{{ OBJECT }}->propertyName',
+            ],
+            'has castTo' => [
+                'expression' => new ObjectPropertyAccessExpression(
+                    VariablePlaceholder::createDependency('OBJECT'),
+                    'propertyName',
+                    'string'
+                ),
+                'expectedString' => '(string) {{ OBJECT }}->propertyName',
             ],
         ];
     }


### PR DESCRIPTION
Fixes #103