### PR TITLE
Render ClosureExpression without calling CodeBlock::getLines()

### DIFF
--- a/src/Line/ClosureExpression.php
+++ b/src/Line/ClosureExpression.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSource\Line;
 
 use webignition\BasilCompilableSource\Block\CodeBlockInterface;
-use webignition\BasilCompilableSource\Line\Statement\StatementInterface;
 use webignition\BasilCompilableSource\Metadata\MetadataInterface;
 
 class ClosureExpression extends AbstractExpression
 {
     private const RENDER_TEMPLATE = <<<'EOD'
 (function () {
-%s%s
+%s
 })()
 EOD;
 
@@ -37,34 +36,9 @@ EOD;
 
     public function render(): string
     {
-        $codeBlockLines = $this->codeBlock->getLines();
-
-        $renderedBodyStatements = '';
-        $renderedFinalStatement = '';
-
-        if (count($codeBlockLines) > 0) {
-            $finalStatement = array_pop($codeBlockLines);
-            $bodyStatements = $codeBlockLines;
-
-            $renderedBodyStatements = (string) array_reduce(
-                $bodyStatements,
-                function (?string $content, StatementInterface $statement) {
-                    return $content . $statement->render() . "\n";
-                }
-            );
-
-            $renderedBodyStatements = $this->indent($renderedBodyStatements);
-            $renderedFinalStatement = $this->indent($finalStatement->render());
-        }
-
-        if ('' !== $renderedBodyStatements) {
-            $renderedBodyStatements .= "\n";
-        }
-
         return sprintf(
             self::RENDER_TEMPLATE,
-            $renderedBodyStatements,
-            $renderedFinalStatement
+            $this->indent($this->codeBlock->render())
         );
     }
 

--- a/tests/Unit/Line/ClosureExpressionTest.php
+++ b/tests/Unit/Line/ClosureExpressionTest.php
@@ -9,6 +9,7 @@ use webignition\BasilCompilableSource\Block\CodeBlockInterface;
 use webignition\BasilCompilableSource\Line\CastExpression;
 use webignition\BasilCompilableSource\Line\ClosureExpression;
 use webignition\BasilCompilableSource\Line\CompositeExpression;
+use webignition\BasilCompilableSource\Line\EmptyLine;
 use webignition\BasilCompilableSource\Line\LiteralExpression;
 use webignition\BasilCompilableSource\Line\MethodInvocation\MethodInvocation;
 use webignition\BasilCompilableSource\Line\MethodInvocation\ObjectMethodInvocation;
@@ -142,6 +143,7 @@ class ClosureExpressionTest extends \PHPUnit\Framework\TestCase
                     new CodeBlock([
                         new Statement(new LiteralExpression('3')),
                         new Statement(new LiteralExpression('4')),
+                        new EmptyLine(),
                         new ReturnStatement(new LiteralExpression('5')),
                     ])
                 ),
@@ -163,6 +165,7 @@ class ClosureExpressionTest extends \PHPUnit\Framework\TestCase
                                 'dependencyMethodName'
                             )
                         ),
+                        new EmptyLine(),
                         new ReturnStatement(
                             new CompositeExpression([
                                 new CastExpression(


### PR DESCRIPTION
Fixes #127