### PR TITLE
Render DocBlock without calling Block::getLines()

### DIFF
--- a/src/Block/DocBlock.php
+++ b/src/Block/DocBlock.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace webignition\BasilCompilableSource\Block;
 
 use webignition\BasilCompilableSource\Line\EmptyLine;
-use webignition\BasilCompilableSource\Line\SingleLineComment;
+use webignition\BasilCompilableSource\Line\Literal;
 use webignition\BasilCompilableSource\LineInterface;
 
 class DocBlock extends AbstractBlock implements BlockInterface
@@ -14,22 +14,25 @@ class DocBlock extends AbstractBlock implements BlockInterface
 
     public function canLineBeAdded(LineInterface $line): bool
     {
-        return $line instanceof SingleLineComment || $line instanceof EmptyLine;
+        return $line instanceof EmptyLine || $line instanceof Literal;
     }
 
     public function render(): string
     {
-        $renderedLines = [];
-
-        foreach ($this->getLines() as $line) {
-            $renderedLine = "\n" . ' *';
-
-            if ($line instanceof SingleLineComment) {
-                $renderedLine .= ' ' . $line->getContent();
-            }
-
-            $renderedLines[] = $renderedLine;
+        $renderedContent = parent::render();
+        if ('' === $renderedContent) {
+            return sprintf(self::RENDER_TEMPLATE, '');
         }
+
+        $renderedLines = explode("\n", $renderedContent);
+
+        array_walk($renderedLines, function (string &$renderedLine) {
+            $prefix = "\n" . ' *';
+
+            $renderedLine = '' === $renderedLine
+                ? $prefix
+                : $prefix . ' ' . $renderedLine;
+        });
 
         return sprintf(self::RENDER_TEMPLATE, implode('', $renderedLines));
     }

--- a/src/Line/Literal.php
+++ b/src/Line/Literal.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace webignition\BasilCompilableSource\Line;
+
+use webignition\BasilCompilableSource\AbstractStringLine;
+use webignition\BasilCompilableSource\LineInterface;
+
+class Literal extends AbstractStringLine implements LineInterface
+{
+    protected function getRenderPattern(): string
+    {
+        return '%s';
+    }
+}

--- a/tests/Unit/Block/DocBlockTest.php
+++ b/tests/Unit/Block/DocBlockTest.php
@@ -7,9 +7,9 @@ namespace webignition\BasilCompilableSource\Tests\Unit\Block;
 use webignition\BasilCompilableSource\Block\DocBlock;
 use webignition\BasilCompilableSource\Line\ClassDependency;
 use webignition\BasilCompilableSource\Line\EmptyLine;
+use webignition\BasilCompilableSource\Line\Literal;
 use webignition\BasilCompilableSource\Line\MethodInvocation\MethodInvocation;
 use webignition\BasilCompilableSource\Line\MethodInvocation\ObjectMethodInvocation;
-use webignition\BasilCompilableSource\Line\SingleLineComment;
 use webignition\BasilCompilableSource\Line\Statement\AssignmentStatement;
 use webignition\BasilCompilableSource\Line\Statement\Statement;
 use webignition\BasilCompilableSource\LineInterface;
@@ -60,11 +60,11 @@ class DocBlockTest extends \PHPUnit\Framework\TestCase
                     ),
                     new ClassDependency(ClassDependency::class),
                     new EmptyLine(),
-                    new SingleLineComment('single line comment'),
+                    new Literal('single line comment'),
                 ],
                 'expectedLines' => [
                     new EmptyLine(),
-                    new SingleLineComment('single line comment'),
+                    new Literal('single line comment'),
                 ],
             ],
         ];
@@ -90,7 +90,7 @@ class DocBlockTest extends \PHPUnit\Framework\TestCase
             'non-empty' => [
                 'docBlock' => new DocBlock([
                     new EmptyLine(),
-                    new SingleLineComment('single line comment'),
+                    new Literal('single line comment'),
                 ]),
                 'expectedString' =>
                     '/**' . "\n" .

--- a/tests/Unit/ClassDefinitionTest.php
+++ b/tests/Unit/ClassDefinitionTest.php
@@ -12,6 +12,7 @@ use webignition\BasilCompilableSource\ClassDefinitionInterface;
 use webignition\BasilCompilableSource\DataProviderMethodDefinition;
 use webignition\BasilCompilableSource\Line\ClassDependency;
 use webignition\BasilCompilableSource\Line\EmptyLine;
+use webignition\BasilCompilableSource\Line\Literal;
 use webignition\BasilCompilableSource\Line\LiteralExpression;
 use webignition\BasilCompilableSource\Line\MethodInvocation\MethodInvocation;
 use webignition\BasilCompilableSource\Line\MethodInvocation\ObjectMethodInvocation;
@@ -288,7 +289,7 @@ class ClassDefinitionTest extends TestCase
                                 ]
                             ),
                             new DocBlock([
-                                new SingleLineComment('@dataProvider stepOneDataProvider')
+                                new Literal('@dataProvider stepOneDataProvider')
                             ])
                         ),
                         new DataProviderMethodDefinition('stepOneDataProvider', [

--- a/tests/Unit/MethodDefinitionTest.php
+++ b/tests/Unit/MethodDefinitionTest.php
@@ -8,6 +8,7 @@ use webignition\BasilCompilableSource\Block\CodeBlock;
 use webignition\BasilCompilableSource\Block\CodeBlockInterface;
 use webignition\BasilCompilableSource\Block\DocBlock;
 use webignition\BasilCompilableSource\Line\EmptyLine;
+use webignition\BasilCompilableSource\Line\Literal;
 use webignition\BasilCompilableSource\Line\LiteralExpression;
 use webignition\BasilCompilableSource\Line\MethodInvocation\MethodInvocation;
 use webignition\BasilCompilableSource\Line\MethodInvocation\ObjectMethodInvocation;
@@ -308,7 +309,7 @@ class MethodDefinitionTest extends \PHPUnit\Framework\TestCase
                         ['x', 'y']
                     ),
                     new DocBlock([
-                        new SingleLineComment('@dataProvider nameOfMethodDataProvider'),
+                        new Literal('@dataProvider nameOfMethodDataProvider'),
                     ])
                 ),
                 'expectedString' =>


### PR DESCRIPTION
Fixes #129